### PR TITLE
Fixing issue with paginated results not using proper url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![snyk-oss-category](https://github.com/snyk-labs/oss-images/blob/main/oss-community.jpg)
 
-# Migrate to GitHub Cloud App
+# Migrate to GitHub Cloud App or GitHub Server App
 
 ## Introduction
 
@@ -41,7 +41,7 @@ snyk-migrate-to-github-app --help
 
 All you need to run the tool is a [Snyk API token](https://docs.snyk.io/getting-started/how-to-obtain-and-authenticate-with-your-snyk-api-token) and the Organization ID of the Organization where you want to migrate your targets to the new GitHub Cloud App or GitHub Server App
 
-**Before Running the Tool:** It is assumed that the GitHub Cloud App integration has already been configured in the Snyk Organization where you will be migrating targets
+**Before Running the Tool:** It is assumed that the GitHub Cloud App or GitHub Server App integration has already been configured in the Snyk Organization where you will be migrating targets
 
 To show the usage in the terminal
 ```shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snyk-migrate-to-github-app"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Troy Havelock <troy.havelock@snyk.io>"]
 readme = "README.md"

--- a/snyk_migrate_to_github_app/main.py
+++ b/snyk_migrate_to_github_app/main.py
@@ -15,9 +15,9 @@ from typing_extensions import Annotated
 SNYK_V1_API_BASE_URL        = 'https://snyk.io/api/v1'
 SNYK_V1_API_BASE_URL_AU     = 'https://api.au.snyk.io/v1'
 SNYK_V1_API_BASE_URL_EU     = 'https://api.eu.snyk.io/v1/'
-SNYK_REST_API_BASE_URL      = 'https://api.snyk.io/rest'
-SNYK_REST_API_BASE_URL_AU   = 'https://api.au.snyk.io/rest'
-SNYK_REST_API_BASE_URL_EU   = 'https://api.eu.snyk.io/rest'
+SNYK_REST_API_BASE_URL      = 'https://api.snyk.io'
+SNYK_REST_API_BASE_URL_AU   = 'https://api.au.snyk.io'
+SNYK_REST_API_BASE_URL_EU   = 'https://api.eu.snyk.io'
 SNYK_REST_API_VERSION       = '2024-08-25'
 SNYK_HIDDEN_API_BASE_URL    = 'https://api.snyk.io/hidden'
 SNYK_HIDDEN_API_BASE_URL_AU = 'https://api.au.snyk.io/hidden'
@@ -172,7 +172,7 @@ def get_all_targets(snyk_token, org_id, origin='github-enterprise', tenant=''):
     if tenant == 'eu':
         base_url = SNYK_REST_API_BASE_URL_EU
 
-    url = f'{base_url}/orgs/{org_id}/targets?version={SNYK_REST_API_VERSION}&limit=100&source_types={origin}&exclude_empty=false'
+    url = f'{base_url}/rest/orgs/{org_id}/targets?version={SNYK_REST_API_VERSION}&limit=100&source_types={origin}&exclude_empty=false'
 
     while True:
         response = requests.request(


### PR DESCRIPTION
When retrieving paginated results for full list of targets, `rest` was prepended to the `next` url which interfered with `rest` on the `base_url` variable. Modified the logic to address this.